### PR TITLE
copy usb_driver to current incorrect path in plugdata

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -14,6 +14,8 @@ copy .\resources\terrarium.json .\Heavy\usr\etc\terrarium.json
 copy .\resources\versio.json .\Heavy\usr\etc\versio.json
 copy .\resources\hothouse.json .\Heavy\usr\etc\hothouse.json
 xcopy /E /H /C /I resources\usb_driver Heavy\usr\etc\usb_driver
+:: fix issue in current plugdata
+xcopy /E /H /C /I resources\usb_driver Heavy\etc\usb_driver
 
 del /S /Q ".\Heavy\usr\arm-none-eabi\lib\arm"
 


### PR DESCRIPTION
Apparently we are using the wrong path in plugdata!

This puts an extra copy so that current users will be able to use the toolchain, but we should also fix this in future versions of plugdata: https://github.com/plugdata-team/plugdata/blob/main/Source/Heavy/ToolchainInstaller.h#L209

This will temporarily resolve #52 